### PR TITLE
Allow output callbacks if mic permission was denied.

### DIFF
--- a/Superpowered/OpenSource/SuperpoweredAndroidAudioIO.cpp
+++ b/Superpowered/OpenSource/SuperpoweredAndroidAudioIO.cpp
@@ -193,6 +193,7 @@ SuperpoweredAndroidAudioIO::SuperpoweredAndroidAudioIO(int samplerate, int buffe
             free(internals->inputFifo.buffer);
             internals->inputFifo.buffer = NULL;
             enableInput = false;
+            internals->hasInput = false;
         }
     };
 


### PR DESCRIPTION
If the instance of Android Audio was created with enableInput=true, enableOutput=true and mic permission wasn't granted, then the output callback won't be fired, because it'll assume that there's an input callback that should arrive.