### PR TITLE
Fix docs regarding Android NDK

### DIFF
--- a/Examples_Android/SuperpoweredCrossExample/app/build.gradle
+++ b/Examples_Android/SuperpoweredCrossExample/app/build.gradle
@@ -31,7 +31,7 @@ android { // main settings for your application
         }
     }
 
-    ndkPath "/Volumes/iMect/android/ndk/25.1.8937393"
+    ndkVersion '25.1.8937393'
 }
 
 dependencies {

--- a/Examples_Android/SuperpoweredEffect/app/build.gradle
+++ b/Examples_Android/SuperpoweredEffect/app/build.gradle
@@ -31,7 +31,7 @@ android { // main settings for your application
         }
     }
 
-    ndkPath "/Volumes/iMect/android/ndk/25.1.8937393"
+    ndkVersion '25.1.8937393'
 }
 
 dependencies {

--- a/Examples_Android/SuperpoweredFrequencyDomain/app/build.gradle
+++ b/Examples_Android/SuperpoweredFrequencyDomain/app/build.gradle
@@ -31,7 +31,7 @@ android { // main settings for your application
         }
     }
 
-    ndkPath "/Volumes/iMect/android/ndk/25.1.8937393"
+    ndkVersion '25.1.8937393'
 }
 
 dependencies {

--- a/Examples_Android/SuperpoweredPlayer/app/build.gradle
+++ b/Examples_Android/SuperpoweredPlayer/app/build.gradle
@@ -31,7 +31,7 @@ android { // main settings for your application
         }
     }
 
-    ndkPath "/Volumes/iMect/android/ndk/25.1.8937393"
+    ndkVersion '25.1.8937393'
 }
 
 dependencies {

--- a/Examples_Android/SuperpoweredRecorder/app/build.gradle
+++ b/Examples_Android/SuperpoweredRecorder/app/build.gradle
@@ -31,7 +31,7 @@ android { // main settings for your application
         }
     }
 
-    ndkPath "/Volumes/iMect/android/ndk/23.1.7779620/android-ndk-r23b"
+    ndkVersion '25.1.8937393'
 }
 
 dependencies {

--- a/Examples_Android/SuperpoweredUSBExample/complexusb/build.gradle
+++ b/Examples_Android/SuperpoweredUSBExample/complexusb/build.gradle
@@ -31,7 +31,7 @@ android { // main settings for your application
         }
     }
 
-    ndkPath "/Volumes/iMect/android/ndk/25.1.8937393"
+    ndkVersion '25.1.8937393'
 }
 
 dependencies {

--- a/Examples_Android/SuperpoweredUSBExample/simpleusb/build.gradle
+++ b/Examples_Android/SuperpoweredUSBExample/simpleusb/build.gradle
@@ -31,7 +31,7 @@ android { // main settings for your application
         }
     }
 
-    ndkPath "/Volumes/iMect/android/ndk/25.1.8937393"
+    ndkVersion '25.1.8937393'
 }
 
 dependencies {

--- a/README.md
+++ b/README.md
@@ -178,7 +178,7 @@ Superpowered USB Audio classes for Android are compatible from Android 19 (KitKa
 
 # Android Studio
 
-Before running any Android example project, please set up the appropriate Android SDK and NDK paths in File - Project Structure... Furthermore, turn off Instant Run in the settings, because the Instant Run feature of Android Studio is not compatible with native C++ Android projects.
+Before running any Android example project, please install the Android NDK version 25.1.8937393 (Tools → SDK Manager → SDK Tools → NDK (Side by side)). Furthermore, turn off Instant Run in the settings, because the Instant Run feature of Android Studio is not compatible with native C++ Android projects.
 
 
 # How to create a Superpowered project with Android Studio


### PR DESCRIPTION
Android NDK path setting instructions are not applicable anymore, setting version in build.gradle files now.