### PR TITLE
Fixes to the android usb-sample apps

### DIFF
--- a/Examples_Android/SuperpoweredUSBExample/simpleusb/src/main/java/com/superpowered/simpleusb/SuperpoweredUSBAudio.java
+++ b/Examples_Android/SuperpoweredUSBExample/simpleusb/src/main/java/com/superpowered/simpleusb/SuperpoweredUSBAudio.java
@@ -21,7 +21,7 @@ public class SuperpoweredUSBAudio {
     public SuperpoweredUSBAudio(Context c, SuperpoweredUSBAudioHandler h) {
         context = c;
         handler = h;
-        permissionIntent = PendingIntent.getBroadcast(context, 0, new Intent(ACTION_USB_PERMISSION), PendingIntent.FLAG_IMMUTABLE);
+        permissionIntent = PendingIntent.getBroadcast(context, 0, new Intent(ACTION_USB_PERMISSION), PendingIntent.FLAG_MUTABLE);
 
         BroadcastReceiver usbReceiver = new BroadcastReceiver() {
             @Override
@@ -61,20 +61,27 @@ public class SuperpoweredUSBAudio {
     private void addUSBDevice(UsbDevice device) {
         UsbManager manager = (UsbManager)context.getSystemService(Context.USB_SERVICE);
         if (manager == null) return;
+
+        if (!manager.hasPermission(device)) {
+            manager.requestPermission(device, permissionIntent);
+            return;
+        }
+
         UsbDeviceConnection connection = manager.openDevice(device);
         if (connection != null) {
             int id = device.getDeviceId();
             switch (onConnect(id, connection.getFileDescriptor(), connection.getRawDescriptors())) {
+                case 0: // Audio and MIDI device.
+                    if (handler != null) handler.onUSBAudioDeviceAttached(id);
+                    if (handler != null) handler.onUSBMIDIDeviceAttached(id);
+                    break;
                 case 1: // Audio device.
                     if (handler != null) handler.onUSBAudioDeviceAttached(id);
                     break;
                 case 2: // MIDI device.
                     if (handler != null) handler.onUSBMIDIDeviceAttached(id);
                     break;
-                case 3: // Audio and MIDI device.
-                    if (handler != null) handler.onUSBAudioDeviceAttached(id);
-                    if (handler != null) handler.onUSBMIDIDeviceAttached(id);
-                    break;
+                case 3: break; // Found no audio or MIDI features for this device.
             }
         }
     }


### PR DESCRIPTION
- Changed mutability flag to PendingIntent.FLAG_MUTABLE (with PendingIntent.FLAG_IMMUTABLE the usb permission is not always granted. See: https://stackoverflow.com/questions/73131973/android-external-fingerprint-usb-always-returns-false-on-usb-permission and https://stackoverflow.com/questions/73267829/androidstudio-usb-extra-permission-granted-returns-false-always/
- Always request device permission before opening a device (this was not the case when “check()” function was called and the usb device was connected before launching the app)
- Remapped “OnConnectReturn” enum values since it was not handling the “0” and “3” case (AudioAndMIDISuccess) correctly.