### PR TITLE
Fix inputBuffer free

### DIFF
--- a/Superpowered/OpenSource/SuperpoweredIOSAudioIO.mm
+++ b/Superpowered/OpenSource/SuperpoweredIOSAudioIO.mm
@@ -181,8 +181,8 @@ static unsigned int nearestPowerOfTwo(unsigned int n) {
         AudioComponentInstanceDispose(audioUnit);
     };
     if (inputBuffer) {
-        if (interleaved) for (int n = 0; n < numberOfChannels; n++) free(inputBuffer->mBuffers[n].mData);
-        else free(inputBuffer->mBuffers[0].mData);
+        if (interleaved) free(inputBuffer->mBuffers[0].mData);
+        else for (int n = 0; n < numberOfChannels; n++) free(inputBuffer->mBuffers[n].mData);
         free(inputBuffer);
     };
     if (inputBufs) free(inputBufs);


### PR DESCRIPTION
Non-interleaved support was added in f229c7b0f7185e4f0962d544190af7e5fcfcce1b

Previous to this commit, the default was interleaved, meaning there was only ever one mBuffers.

With non-interleaved support, there are numberOfChannels mBuffers.

The allocation of these buffers is shown in createInputBuffer wherein

    if (interleaved) {
        ...
        inputBuffer->mBuffers[0].mData = calloc(1, MAXFRAMES * 4 * numberOfChannels);
        ...
    } else {
        inputBuffer = (AudioBufferList *)malloc(offsetof(AudioBufferList, mBuffers[0]) + sizeof(AudioBuffer) * numberOfChannels);
        ...
        for (int n = 0; n < numberOfChannels; n++) {
            inputBuffer->mBuffers[n].mData = inputBufs[n] = (float *)calloc(1, MAXFRAMES * 4);
            ...
        }
    }

Therefore when freeing inputBuffer, interleaved == true should free one mBuffers and interleaved == false should free numberOfChannels mBuffers.